### PR TITLE
Add options page to store title's deny list

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,6 +9,7 @@
   "background": {
     "scripts": ["dist/background/index.js"]
   },
+  "permissions": ["storage"],
   "host_permissions": ["*://*.linkedin.com/jobs/search/*"],
   "content_scripts": [
     {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@tsconfig/recommended": "^1.0.5",
     "@types/react": "^18.2.74",
     "@types/react-dom": "^18.2.23",
+    "@types/webextension-polyfill": "^0.10.7",
     "html-webpack-plugin": "^5.6.0",
     "husky": "^9.0.11",
     "lint-staged": "^15.2.2",
@@ -28,6 +29,7 @@
     "ts-loader": "^9.5.1",
     "typescript": "^5.4.3",
     "web-ext": "^7.11.0",
+    "webextension-polyfill": "^0.10.0",
     "webpack": "^5.91.0",
     "webpack-cli": "^5.1.4"
   },

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -1,15 +1,29 @@
 import React, { useState } from "react";
 
+enum FormField {
+  denyList = "denyList",
+}
+
 interface FormData {
-  denyList: String;
+  [FormField.denyList]: string[] | undefined;
 }
 
 export default function App() {
-  const [formData, setFormData] = useState({});
+  const [formData, setFormData] = useState<FormData>({} as FormData);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    console.log(formData);
+  };
+
+  const handleChange = (key: string, value: any) => {
+    setFormData({ ...formData, [key]: value });
+  };
 
   return (
     <>
-      <form>
+      <form onSubmit={handleSubmit}>
         <label>Deny List (regexp)</label>
         <br />
         <sub>
@@ -18,34 +32,17 @@ export default function App() {
         </sub>
         <br />
         <textarea
-          id="deny-list"
-          name="deny-list"
+          id={FormField.denyList}
+          name={FormField.denyList}
           rows={4}
           cols={50}
-          placeholder=""
+          value={formData[FormField.denyList]?.join("\n")}
+          onChange={(event) =>
+            handleChange(FormField.denyList, event.target.value.split("\n"))
+          }
         ></textarea>
 
         <br />
-
-        <label>Check for Visa Sponshorship?</label>
-        <input
-          id="check-for-visa-sponsorship"
-          type="checkbox"
-          name="check-for-visa-sponsorship"
-        />
-
-        <br />
-
-        <label>Match Threshold</label>
-        <input
-          id="match-threshold"
-          name="match-threshold"
-          type="range"
-          min="0"
-          max="100"
-          step="5"
-          value={1}
-        />
 
         <button type="submit">Save</button>
       </form>

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -1,24 +1,29 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
+import browser from "webextension-polyfill";
 
 enum FormField {
   denyList = "denyList",
 }
 
-interface FormData {
-  [FormField.denyList]: string[] | undefined;
+interface Options {
+  [FormField.denyList]: string[];
 }
 
 export default function App() {
-  const [formData, setFormData] = useState<FormData>({} as FormData);
+  const [options, setOptions] = useState<Options>({
+    [FormField.denyList]: [],
+  } as Options);
 
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+  // Initializes the form with data from storage
+  useEffect(() => {
+    browser.storage.local
+      .get("options")
+      .then((data) => setOptions(data.options));
+  }, []);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-
-    console.log(formData);
-  };
-
-  const handleChange = (key: string, value: any) => {
-    setFormData({ ...formData, [key]: value });
+    await browser.storage.local.set({ options: options });
   };
 
   return (
@@ -36,9 +41,12 @@ export default function App() {
           name={FormField.denyList}
           rows={4}
           cols={50}
-          value={formData[FormField.denyList]?.join("\n")}
+          value={options[FormField.denyList].join("\n")}
           onChange={(event) =>
-            handleChange(FormField.denyList, event.target.value.split("\n"))
+            setOptions({
+              ...options,
+              [FormField.denyList]: event.target.value.split("\n"),
+            })
           }
         ></textarea>
 


### PR DESCRIPTION
### Summary
This change adjust the options page to start storing settings - it uses the extension local storage to store the data. The data will later be used by the background script(s) to implement the additional filters missing from Linkedin Job Search UX.

### Testing
![image](https://github.com/marioluan/linkedin-job-search-purifier/assets/2514197/5af97341-dcc3-4cc9-8668-e9cc19f53a2d)
![image](https://github.com/marioluan/linkedin-job-search-purifier/assets/2514197/cd7bf507-e980-4d85-8090-7897f0204628)
