### PR TITLE
allow propagating multiple deny lists

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1,6 +1,7 @@
 import browser from "webextension-polyfill";
 import { LinkedinDatasetFilterer, LinkedinUrnMapper } from "./linkedin";
 import { stringToRegExp } from "./util";
+import { ExtensionOptions } from "./dto";
 
 function decodeAndParseData(decoder: TextDecoder, data: ArrayBuffer[]): any {
   let chunks = "";
@@ -21,9 +22,11 @@ async function listenForVoyagerJobsDashJobCards(
   const filter = browser.webRequest.filterResponseData(details.requestId);
   const decoder = new TextDecoder("utf-8");
   const encoder = new TextEncoder();
-  const { options } = await browser.storage.local.get("options");
+  const options = await browser.storage.local
+    .get("options")
+    .then((data) => data.options as ExtensionOptions);
   const linkedinDatasetFilterer = new LinkedinDatasetFilterer(
-    options.denyList.map(stringToRegExp),
+    options.denyList.titles.map(stringToRegExp),
     new LinkedinUrnMapper(),
   );
 

--- a/src/dto.ts
+++ b/src/dto.ts
@@ -1,0 +1,5 @@
+export interface ExtensionOptions {
+  denyList: {
+    titles: string[];
+  };
+}

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -2,19 +2,18 @@ import React, { useEffect, useState } from "react";
 import browser from "webextension-polyfill";
 import Button from "@mui/material/Button";
 import Snackbar from "@mui/material/Snackbar";
+import { ExtensionOptions } from "../dto";
 
 enum FormField {
-  denyList = "denyList",
+  titleDenyList = "titleDenyList",
 }
 
-interface Options {
-  [FormField.denyList]: string[];
-}
-
-const initialOptions = { [FormField.denyList]: [] };
+const initialOptions: ExtensionOptions = {
+  denyList: { titles: [] },
+};
 
 export default function App() {
-  const [options, setOptions] = useState<Options>(initialOptions);
+  const [options, setOptions] = useState<ExtensionOptions>(initialOptions);
   const [showNotification, setShowNotification] = useState(false);
   const [notification, setNotification] = useState<string>();
 
@@ -40,23 +39,23 @@ export default function App() {
   return (
     <>
       <form onSubmit={handleSubmit} onReset={handleReset}>
-        <label>Deny List (regexp)</label>
+        <label>Job Titles to Exclude (regexp)</label>
         <br />
-        <sub>
-          One per line. Will be applied to filter out jobs' titles matching
-          these.
-        </sub>
+        <sub>One per line.</sub>
         <br />
         <textarea
-          id={FormField.denyList}
-          name={FormField.denyList}
+          id={FormField.titleDenyList}
+          name={FormField.titleDenyList}
           rows={4}
           cols={50}
-          value={options[FormField.denyList].join("\n")}
+          value={options.denyList.titles.join("\n")}
           onChange={(event) => {
             setOptions({
               ...options,
-              [FormField.denyList]: event.target.value.split("\n"),
+              denyList: {
+                ...options.denyList,
+                titles: event.target.value.split("\n"),
+              },
             });
           }}
         />


### PR DESCRIPTION
Turning the Options.denyList into a hash map to allow adding multiple lists, such as companies and titles together.