### PR TITLE
add companies deny list

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -27,6 +27,7 @@ async function listenForVoyagerJobsDashJobCards(
     .then((data) => data.options || DefaultExtensionOptions);
   const linkedinDatasetFilterer = new LinkedinDatasetFilterer(
     options.denyList.titles.map(stringToRegExp),
+    options.denyList.companies.map(stringToRegExp),
     new LinkedinUrnMapper(),
   );
 

--- a/src/dto.ts
+++ b/src/dto.ts
@@ -1,9 +1,10 @@
 export interface ExtensionOptions {
   denyList: {
     titles: string[];
+    companies: string[];
   };
 }
 
 export const DefaultExtensionOptions: ExtensionOptions = {
-  denyList: { titles: [] },
+  denyList: { titles: [], companies: [] },
 };


### PR DESCRIPTION
I had to iterate over the `included` dataset twice, because the company information is present on JobPostingCard, not on JobPosting. Also had to change the logic to collect the job posting ids to exclude, instead of to keep. Add a new field to the UI and fixed a bug that was storing empty deny lists with a single empty string element, breaking app when no regexp is included.